### PR TITLE
add color and fonts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.13.9-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.9-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.9-x86_64-linux)
@@ -244,6 +246,7 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-21
   x86_64-linux
 

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -1,10 +1,10 @@
 // Define variables for your color scheme
 
 // For example:
-$red: #FD1015;
-$blue: #0D6EFD;
-$yellow: #FFC65A;
-$orange: #E67E22;
-$green: #1EDD88;
-$gray: #0E0000;
-$light-gray: #F4F4F4;
+$pri-teal: #3a8891;
+$sec-teal: #0e5e6f;
+$pri-salmon: #ff9477;
+$sec-salmon: #ffe0d6;
+$alm-black: #072a32;
+$alm-white: #fff9f8;
+$white: #ffffff;

--- a/app/assets/stylesheets/config/_fonts.scss
+++ b/app/assets/stylesheets/config/_fonts.scss
@@ -1,9 +1,9 @@
 // Import Google fonts
-@import url('https://fonts.googleapis.com/css?family=Nunito:400,700|Work+Sans:400,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@200;400;500&family=Source+Sans+Pro:ital,wght@0,300;0,700;1,300&display=swap');
 
 // Define fonts for body and headers
-$body-font: "Work Sans", "Helvetica", "sans-serif";
-$headers-font: "Nunito", "Helvetica", "sans-serif";
+$body-font: "Source Sans Pro", "sans-serif";
+$headers-font: "Source Code Pro", "serif";
 
 // To use a font file (.woff) uncomment following lines
 // @font-face {


### PR DESCRIPTION
Added our color palette to _colors.scss
Added our google fonts to _fonts.scss

Attention: 
Headers-fonts are set as "Source Code Pro" (the 'developing' font)
Body-fonts are set as "Source Sans Pro" (the cleaner font)

If we want to change the H1 or others to SANS PRO like the Hi-Fi Prototype, we have to add it manually as as css style.